### PR TITLE
feat(pets): add pinPet helper to remember preferred pet

### DIFF
--- a/lib/pin-pet.mjs
+++ b/lib/pin-pet.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const PINNED_FILE = 'hermes-classic-gold-pack.pinned.json'
+
+/**
+ * Remember the user's preferred pet so a later reinstall can re-activate it
+ * without re-prompting. Writes <HERMES_HOME>/hermes-classic-gold-pack.pinned.json.
+ *
+ * @param {string} home   HERMES_HOME
+ * @param {string} slug   pet slug to pin
+ * @param {object} [opts]
+ * @param {string} [opts.nowIso]  injectable timestamp (tests / deterministic runs)
+ * @returns {string} the pinned-file path
+ */
+export function pinPet(home, slug, { nowIso } = {}) {
+  const path = join(home, PINNED_FILE)
+  const record = { slug, pinnedAt: nowIso || new Date().toISOString() }
+  writeFileSync(path, JSON.stringify(record, null, 2))
+  return path
+}

--- a/test/pin-pet.test.mjs
+++ b/test/pin-pet.test.mjs
@@ -1,0 +1,15 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pinPet, PINNED_FILE } from '../lib/pin-pet.mjs'
+
+test('pinPet writes the pinned record into HERMES_HOME', () => {
+  const home = mkdtempSync(join(tmpdir(), 'gold-pin-'))
+  const p = pinPet(home, 'noir-neko', { nowIso: '2026-01-01T00:00:00Z' })
+  assert.ok(existsSync(p))
+  const rec = JSON.parse(readFileSync(join(home, PINNED_FILE), 'utf8'))
+  assert.equal(rec.slug, 'noir-neko')
+  assert.equal(rec.pinnedAt, '2026-01-01T00:00:00Z')
+})


### PR DESCRIPTION
Adds a `pinPet(home, slug)` helper that records the user's preferred pet in `<HERMES_HOME>/hermes-classic-gold-pack.pinned.json`, so a later reinstall can re-activate it without re-prompting. Includes a unit test. Wiring into `install.mjs --activate` will follow in a second PR.

---
🧪 **Sandbox PR** — opened to exercise the automated Codex review loop end-to-end. Please review normally; **not intended for merge.**