### PR TITLE
Add easy plug-in folder install and v1.2.0 release bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+/dist/
 *.orig
 *.bak
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ auto-detected checkout when more than one checkout can match.
 
 ## Install
 
+### Easy folder install
+
+For a no-terminal Windows install, download
+`Hermes-Classic-Gold-v1.2.0.zip` from the latest GitHub release. Fully quit
+Hermes, then copy the ZIP's `desktop-plugins` and `plugins` folders into
+`%LOCALAPPDATA%\hermes`. Start Hermes, enable **Classic Gold** in **Settings >
+Plugins**, restart Hermes, and select **Classic Hermes** in **Settings >
+Appearance**.
+
+See [`docs/EASY-INSTALL.md`](docs/EASY-INSTALL.md) for the step-by-step guide.
+Use only the prepared release ZIP. The repository renderer source still needs
+its release build step.
+
+Prefer an AI agent? Copy an install, troubleshooting, update, or safe-removal
+prompt from [`docs/AI-AGENT-PROMPTS.md`](docs/AI-AGENT-PROMPTS.md).
+
+### Managed command install
+
 ```bash
 git clone https://github.com/Elevatormusic/hermes-classic-gold-pack
 cd hermes-classic-gold-pack

--- a/ai/install.md
+++ b/ai/install.md
@@ -3,6 +3,12 @@
 Install Classic Gold through the supported Hermes Desktop plug-in boundary. Do
 not patch or rebuild the Hermes checkout.
 
+For a user who explicitly wants a no-terminal folder copy, use the prepared
+release ZIP and follow [`../docs/EASY-INSTALL.md`](../docs/EASY-INSTALL.md).
+Copy-ready agent prompts are in
+[`../docs/AI-AGENT-PROMPTS.md`](../docs/AI-AGENT-PROMPTS.md). Do not copy the
+renderer source file directly.
+
 ## Procedure
 
 1. Clone this repository. Read `README.md` and `SECURITY.md`.

--- a/docs/AI-AGENT-PROMPTS.md
+++ b/docs/AI-AGENT-PROMPTS.md
@@ -1,0 +1,95 @@
+# Copy a prompt for your AI agent
+
+Use an AI coding agent that can read files and run commands on your computer.
+Copy only the prompt for the task that you want. The agent must stop and ask you
+to select a profile if it finds more than one Hermes profile.
+
+## Install Classic Gold
+
+```text
+Install the latest stable Hermes Classic Gold Pack from
+https://github.com/Elevatormusic/hermes-classic-gold-pack.
+
+Use only the supported run-time plug-in installer. Do not patch Hermes source.
+First find the exact Hermes profile that contains config.yaml. If more than one
+profile exists, stop and ask me which one to use. Read README.md, SECURITY.md,
+AGENTS.md, and ai/install.md before you change files. Check for an old Classic
+Gold source-patch install. If one exists, follow the documented restore-only
+migration before the new install. Do not force a migration or delete user files.
+
+Run the installer dry run against the exact profile and show me the plan. If the
+plan is safe, install the renderer and telemetry backend. Keep my current pet
+unless I ask you to change it. Fully quit and restart Hermes. Confirm that
+Classic Gold is enabled in Settings > Plugins and Classic Hermes is available
+in Settings > Appearance. Verify the installed file hashes and receipts. Test
+the theme, status-bar controls, RAM, VRAM, cost, token rate, and cache hit rate.
+Treat -- as unavailable data, not a failed install. Report the exact profile,
+Pack version, files changed, restart result, and checks. Do not merge, delete,
+or overwrite unrelated files.
+```
+
+## Troubleshoot or fix Classic Gold
+
+```text
+Troubleshoot the existing Hermes Classic Gold installation. Work read-only
+until you identify the cause. Find the exact Hermes profile that contains
+config.yaml. If more than one profile exists, stop and ask me which one to use.
+Read README.md, SECURITY.md, AGENTS.md, ai/repair.md, and ai/issuereport.md from
+the latest stable Classic Gold Pack.
+
+Run the Pack diagnostics and inspect the active stamps, manifest receipts,
+renderer hash, telemetry backend files, plug-in membership, Hermes logs, and
+whether a full restart is pending. Do not apply old source patches. Do not
+delete a full plugins folder, desktop-plugins folder, profile, session, log, or
+user file. Preserve any file that changed after the Pack installed it. Explain
+the cause and the smallest safe fix before you write. Then apply only that fix,
+fully restart Hermes, and verify the theme, status-bar buttons, model-selector
+behavior, RAM, VRAM, actual session cost, token rate, and cache hit rate. Treat
+unknown telemetry as unavailable, not zero. Report live, static, skipped, and
+unavailable checks separately.
+```
+
+## Update Classic Gold
+
+```text
+Update Hermes Classic Gold to the latest stable release without changing
+Hermes source. Find the exact Hermes profile that contains config.yaml. If more
+than one profile exists, stop and ask me which one to use. Read README.md,
+SECURITY.md, AGENTS.md, and ai/update.md from the latest Pack.
+
+Determine whether this is a managed installer install, a manual folder install,
+or an old source-patch install. For a managed install, update the Pack checkout,
+run the dry run against the same exact profile, and rerun the supported
+installer. For a manual folder install, use the prepared ZIP from the latest
+GitHub release and replace only desktop-plugins/classic-gold and
+plugins/classic-gold while Hermes is fully closed. For an old source-patch
+install, complete the documented restore-only migration first. Do not mix these
+methods, force a migration, or overwrite changed user files.
+
+Fully restart Hermes. Verify the release version, installed hashes, plug-in
+membership, Classic Hermes theme, status-bar controls, and available telemetry.
+Report every changed path and the validation result.
+```
+
+## Remove the old theme or uninstall Classic Gold
+
+```text
+Safely remove the old Hermes Classic Gold theme. First identify the exact
+Hermes profile and whether the install is a managed run-time plug-in, a manual
+folder copy, or a legacy source patch. If more than one profile exists, stop and
+ask me which one to use. Read README.md, SECURITY.md, AGENTS.md,
+ai/uninstall.md, and ai/update.md before any write.
+
+Select another theme before removal. For a managed run-time install, run the
+documented uninstall dry run, review its exact receipt proofs, and then use the
+Pack uninstaller. For a manual folder install, fully quit Hermes and remove only
+desktop-plugins/classic-gold and plugins/classic-gold. For a legacy source
+patch, use the restore-only migration and require exact same-version backup or
+Git proof. Never delete the full desktop-plugins, plugins, pets, Hermes profile,
+session, or log folders. Never guess at a backup or overwrite a later user edit.
+
+Restart Hermes and confirm that Classic Gold is disabled, its exact managed
+files are absent or restored, another theme is active, and unrelated plug-ins
+still work. Report what was removed, what was preserved, and any item that could
+not be removed safely.
+```

--- a/docs/EASY-INSTALL.md
+++ b/docs/EASY-INSTALL.md
@@ -1,0 +1,78 @@
+# Easy folder install
+
+Use these steps if you do not want to use a terminal. This method installs the
+Classic Gold theme and status bar. It does not install the optional pets.
+
+## Before you start
+
+Use the ZIP attached to the latest GitHub release. Do not copy the source-code
+folder from GitHub. The release ZIP contains a prepared `plugin.js` file.
+
+If you installed Classic Gold with `node install.mjs`, do not use this folder
+method to update it. Use the normal installer again so its safety records stay
+correct.
+
+Would you rather let an AI agent do the work? Open
+[`AI-AGENT-PROMPTS.md`](AI-AGENT-PROMPTS.md), copy the prompt for your task, and
+paste it into an AI coding agent that can access your computer.
+
+## Windows
+
+1. Download `Hermes-Classic-Gold-v1.2.0.zip` from the latest release.
+2. Right-click the ZIP and select **Extract All**.
+3. Fully quit Hermes Desktop. Check the system tray too.
+4. Press `Windows key + R`.
+5. Enter `%LOCALAPPDATA%\hermes` and select **OK**.
+6. Copy the extracted `desktop-plugins` and `plugins` folders into the open
+   `hermes` folder.
+7. If Windows asks, select **Merge folders** and **Replace files**.
+8. Start Hermes Desktop.
+9. Open **Settings > Plugins** and enable **Classic Gold**.
+10. Fully quit and start Hermes Desktop one more time. This restart loads the
+    telemetry backend.
+11. Open **Settings > Appearance** and select **Classic Hermes**.
+
+If the theme does not appear, open the Command Palette and run **Reload desktop
+plugins**. Then check **Settings > Appearance** again.
+
+## macOS and Linux profile folders
+
+The copy steps are the same. Copy both release folders into the Hermes profile
+that contains `config.yaml`.
+
+- macOS default: `~/Library/Application Support/hermes`
+- Linux default: `~/.local/share/hermes`
+
+If your profile is in another location, use that profile. Do not guess when you
+have more than one Hermes profile.
+
+## Update a folder install
+
+Fully quit Hermes. Download the new release ZIP and replace only these two
+folders:
+
+```text
+desktop-plugins/classic-gold/
+plugins/classic-gold/
+```
+
+Start Hermes again. Your Classic Gold settings remain in Hermes private plug-in
+storage.
+
+## Remove a folder install
+
+These steps apply only to an install made with this folder-copy guide.
+
+1. Select another theme in **Settings > Appearance**.
+2. Disable **Classic Gold** in **Settings > Plugins**.
+3. Fully quit Hermes.
+4. Delete only these two `classic-gold` folders from the Hermes profile:
+
+   ```text
+   desktop-plugins/classic-gold/
+   plugins/classic-gold/
+   ```
+
+5. Start Hermes.
+
+Do not delete the full `desktop-plugins`, `plugins`, or Hermes profile folder.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "bin": { "hermes-classic-gold-pack": "install.mjs" },
   "scripts": {
+    "build-plugin-folder": "node scripts/build-plugin-folder.mjs",
     "diagnostics": "node scripts/diagnostics.mjs",
     "test": "node --test",
     "install-pack": "node install.mjs",

--- a/scripts/build-plugin-folder.mjs
+++ b/scripts/build-plugin-folder.mjs
@@ -1,0 +1,37 @@
+import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { buildDesktopPluginSource, WORDMARK_TOKEN } from '../lib/desktop-plugin.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Build the folder-copy release without changing an existing output folder. */
+export function buildPluginFolderBundle ({ destination } = {}) {
+  const packageData = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'))
+  const target = resolve(destination || join(ROOT, 'dist', `Hermes-Classic-Gold-v${packageData.version}`))
+  if (existsSync(target)) throw new Error(`Output already exists: ${target}`)
+
+  const rendererTarget = join(target, 'desktop-plugins', 'classic-gold', 'plugin.js')
+  const backendTarget = join(target, 'plugins', 'classic-gold', 'dashboard')
+  const renderer = buildDesktopPluginSource(join(ROOT, 'desktop-plugin', 'classic-gold', 'plugin.js'))
+  if (renderer.includes(WORDMARK_TOKEN)) {
+    throw new Error('The built desktop plug-in still contains the wordmark placeholder.')
+  }
+
+  mkdirSync(dirname(rendererTarget), { recursive: true })
+  writeFileSync(rendererTarget, renderer)
+  cpSync(join(ROOT, 'backend', 'classic-gold', 'dashboard'), backendTarget, { recursive: true })
+  copyFileSync(join(ROOT, 'docs', 'EASY-INSTALL.md'), join(target, 'START-HERE.md'))
+  copyFileSync(join(ROOT, 'docs', 'AI-AGENT-PROMPTS.md'), join(target, 'AI-AGENT-PROMPTS.md'))
+
+  return { target, version: packageData.version }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const outputIndex = process.argv.indexOf('--output')
+  const destination = outputIndex >= 0 ? process.argv[outputIndex + 1] : undefined
+  if (outputIndex >= 0 && !destination) throw new Error('--output requires a directory path.')
+  const result = buildPluginFolderBundle({ destination })
+  console.log(`Built Classic Gold ${result.version} folder at ${result.target}`)
+}

--- a/test/build-plugin-folder.test.mjs
+++ b/test/build-plugin-folder.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { buildDesktopPluginSource, WORDMARK_TOKEN } from '../lib/desktop-plugin.mjs'
+import { buildPluginFolderBundle } from '../scripts/build-plugin-folder.mjs'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+test('folder-copy bundle contains the built renderer, backend, and guides', t => {
+  const temporary = mkdtempSync(join(tmpdir(), 'classic-gold-folder-'))
+  const destination = join(temporary, 'bundle')
+  t.after(() => rmSync(temporary, { recursive: true, force: true }))
+
+  const result = buildPluginFolderBundle({ destination })
+  const renderer = readFileSync(join(destination, 'desktop-plugins', 'classic-gold', 'plugin.js'), 'utf8')
+  const expectedRenderer = buildDesktopPluginSource(join(ROOT, 'desktop-plugin', 'classic-gold', 'plugin.js'))
+
+  assert.equal(result.target, destination)
+  assert.equal(renderer, expectedRenderer)
+  assert.equal(renderer.includes(WORDMARK_TOKEN), false)
+  for (const relativePath of ['manifest.json', 'plugin_api.py', join('dist', 'index.js')]) {
+    assert.deepEqual(
+      readFileSync(join(destination, 'plugins', 'classic-gold', 'dashboard', relativePath)),
+      readFileSync(join(ROOT, 'backend', 'classic-gold', 'dashboard', relativePath))
+    )
+  }
+  assert.match(readFileSync(join(destination, 'START-HERE.md'), 'utf8'), /Easy folder install/)
+  assert.match(readFileSync(join(destination, 'AI-AGENT-PROMPTS.md'), 'utf8'), /Copy a prompt/)
+})
+
+test('folder-copy builder does not replace an existing output', t => {
+  const temporary = mkdtempSync(join(tmpdir(), 'classic-gold-folder-'))
+  const destination = join(temporary, 'bundle')
+  t.after(() => rmSync(temporary, { recursive: true, force: true }))
+
+  buildPluginFolderBundle({ destination })
+  assert.throws(() => buildPluginFolderBundle({ destination }), /Output already exists/)
+})


### PR DESCRIPTION
## Summary

- add a no-terminal folder-copy guide for nontechnical Hermes users
- add copy-ready AI agent prompts for install, troubleshooting, update, and safe old-theme removal
- add a reproducible release-folder builder with the prepared renderer, telemetry backend, and guides
- test the complete release layout and prevent accidental output replacement

## Validation

- `npm test`: 206/206 passed
- Node 18 focused bundle tests: 2/2 passed
- Standard: passed
- JavaScript syntax: passed
- `git diff --check`: passed
- built ZIP inspected: prepared renderer, all three backend files, and both guides